### PR TITLE
route reticulate to virtual env

### DIFF
--- a/R/synapse_functions.R
+++ b/R/synapse_functions.R
@@ -1,5 +1,6 @@
 create_synapse_login <- function(){
   if("use_conda_env.R" %in% list.files("R")) source("R/use_conda_env.R")
+  reticulate::usevirtualenv("virtual_env", required = T)
   synapseclient <- reticulate::import("synapseclient")
   syn <- synapseclient$Synapse()
   syn$login()


### PR DESCRIPTION
It seems like this is the first place `reticulate` is called to import `synapseclient` so added the code snippet referred to in https://github.com/Sage-Bionetworks/projectLive_NF/issues/175 here